### PR TITLE
still use apache_migration branch in apache

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -34,8 +34,6 @@ repositories:
 #   job_display_name: optaplanner-website
 - name: incubator-kie-kie-benchmarks
   job_display_name: kie-benchmarks
-  author:
-    name: radtriste # TODO set back. Could not push to kiegroup
 git:
   author:
     name: apache

--- a/.ci/jenkins/config/main.yaml
+++ b/.ci/jenkins/config/main.yaml
@@ -11,7 +11,7 @@ ecosystem:
     - incubator-kie-kie-benchmarks.*
 git:
   branches:
-  - name: main
+  - name: apache_migration
     main_branch: true
 seed:
   config_file:
@@ -19,8 +19,8 @@ seed:
       repository: incubator-kie-optaplanner
       author:
         name: apache
-        credentials_id: kie-ci5
-      branch: main
+        credentials_id: ASF_Cloudbees_Jenkins_ci-builds
+      branch: apache_migration
     path: .ci/jenkins/config/branch.yaml
 jenkins:
   email_creds_id: KOGITO_CI_NOTIFICATION_EMAILS


### PR DESCRIPTION
As long as we're on apache_migration branch we should stick with apache_migration as a replacement for main.